### PR TITLE
Put version number in quotes

### DIFF
--- a/example/publiccode.yml
+++ b/example/publiccode.yml
@@ -29,7 +29,7 @@ description:
       - img/sshot3.jpg
     videos:                                               # Demo videos of the software
       - https://youtube.com/xxxxxxxx 
-    version: 1.0                                          # Last stable version
+    version: "1.0"                                        # Last stable version
     released: 2017-04-15                                  # Date of last stable software release 
     platforms: web                    # or Windows, Mac, Linux, etc. 
 


### PR DESCRIPTION
Force version numbers to be strings. Otherwise, they would be interpreted as float, with the side effect of `1.10` being equivalent to `1.1`