### PR TITLE
Add docker integration for jekyll website.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# Jekyll
 Gemfile.lock
 _site
+.jekyll-metadata
+
+# Mac generic
+.DS_Store
+
+# Windows generic
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.4.0-alpine
+# Add files
+WORKDIR /usr/src/yml.publiccode.net
+ADD . .
+# Install jekyll plugins
+RUN apk add --no-cache --virtual .build-deps build-base ruby-dev
+RUN bundle install
+ENTRYPOINT ["bundle", "exec", "jekyll", "serve", "--incremental", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]

--- a/_config.yml
+++ b/_config.yml
@@ -14,5 +14,9 @@ include:
 # Use the Foundation For Public Code Jekyll theme`
 remote_theme: publiccodenet/jekyll-theme
 
+# Error on docker environment: "Specify using PAGES_REPO_NWO environment variables"
+# https://github.com/jekyll/jekyll/issues/4705
+repository: publiccodenet/publiccode.yml
+
 # Enable Table of Contents displaying
 toc: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.3"
+
+services:
+  yml.publiccode.net:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - .:/usr/src/yml.publiccode.net


### PR DESCRIPTION
This PR adds a Dockerfile for the generation of the docker image and a docker-compose.yml for rapid start and future integrations. It will expose the jekyll website on :4000 and auto-reload every change.

Just clone and run:
`docker-compose up`

This will help if someone wants to contribute but can't/doesn't want to install ruby, jekyll and dependencies on his machine.

@ruphy if the PR will be accepted, where can we write the "instructions" (just clone and run...) :) 

Edit: Travis CI failed on a working link :/