### PR TITLE
For videos, make oEmbed support a "must"

### DIFF
--- a/schema.md
+++ b/schema.md
@@ -470,7 +470,7 @@ Screenshots can be of any shape and size; the suggested formats are:
 
 This key contains one or multiple URLs of videos showing how the
 software works. Like screenshots, videos should be used to give a quick
-overview on how the software looks like and how it works. Videos should
+overview on how the software looks like and how it works. Videos must
 be hosted on a video sharing website that supports the
 [oEmbed](https://oembed.com) standard; popular options are YouTube and
 Vimeo.


### PR DESCRIPTION
It is currently a should, but I'm not sure how a parser is supposed to use a random URL. At least, with oEmbed we have a clear way to retrieve an embedding snippet.